### PR TITLE
Added Configurable class for hidden layer controlling

### DIFF
--- a/src/config/schema_config.py
+++ b/src/config/schema_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, MISSING
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Any
+from typing import Optional, Any, List
 
 
 @dataclass
@@ -41,6 +41,7 @@ class NetworkParams:
     num_layers: int = MISSING
     dim_feedforward: int = MISSING
     hidden_layer: int = MISSING
+    res_block_layers: List[List[int]] = MISSING
 
 
 @dataclass

--- a/src/networks/transformer_nn.py
+++ b/src/networks/transformer_nn.py
@@ -24,61 +24,7 @@ class LinearEmbeddingCosine(nn.Module):
     def get_weights(self):
         return [(name, param) for name, param in self.embedding.named_parameters()]
 
-
 class TransformerEmbeddingCosine(nn.Module):
-    dropout = 0.1
-
-    def __init__(
-        self,
-        input_features=640,
-        dim_feedforward=1280,
-        hidden_layer=640,
-        nhead=10,
-        num_layers=6,
-        res_block_layers=0
-    ):
-        super().__init__()
-        encoder_layer = nn.TransformerEncoderLayer(
-            d_model=input_features,
-            nhead=nhead,
-            dim_feedforward=dim_feedforward,
-            dropout=self.dropout,
-            batch_first=True
-        )
-        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
-        if res_block_layers == 0:
-            self.embedding = nn.Sequential(OrderedDict([
-                ('norm', nn.LayerNorm(input_features)),
-                ('dropout', nn.Dropout(p=self.dropout)),
-                ('linear', nn.Linear(input_features, hidden_layer)),
-                ('activation', nn.ReLU())
-            ]))
-        else:
-            res_block = OrderedDict([(
-                f'block{i}',
-                ResBlock(input_features, hidden_layer, self.dropout)
-            ) for i in range(res_block_layers)])
-            res_block.update([
-                ('dropout', nn.Dropout(p=self.dropout)),
-                ('linear', nn.Linear(input_features, hidden_layer)),
-                ('activation', nn.ReLU())
-            ])
-            self.embedding = nn.Sequential(res_block)
-
-    def embedding_pooling(self, x, x_mask):
-        return self.embedding(self.transformer(x, src_key_padding_mask=x_mask).sum(dim=1))
-
-    def forward(self, x, x_mask, y, y_mask):
-        return nn.functional.cosine_similarity(
-            self.embedding_pooling(x, x_mask),
-            self.embedding_pooling(y, y_mask)
-        )
-
-    def get_weights(self):
-        return [(name, param) for name, param in self.embedding.named_parameters()]
-
-
-class TransformerEmbeddingCosineConfigurable(nn.Module):
     dropout = 0.1
 
     def __init__(
@@ -109,13 +55,11 @@ class TransformerEmbeddingCosineConfigurable(nn.Module):
         else:
             res_block = OrderedDict()
             in_dim = input_features
-            block_id = 0  # needed for unique block names
 
             for out_dim, count in res_block_layers:
-                for i in range(count):
-                    res_block[f'block{block_id}'] = ResBlock(in_dim, out_dim, self.dropout)
-                    in_dim = out_dim  # update input for next block
-                    block_id += 1
+                for i, _ in enumerate(range(count)):
+                    res_block[f'block{i}'] = ResBlock(in_dim, out_dim, self.dropout)
+                    in_dim = out_dim
 
             res_block.update([
                 ('dropout', nn.Dropout(p=self.dropout)),
@@ -125,8 +69,6 @@ class TransformerEmbeddingCosineConfigurable(nn.Module):
 
             self.embedding = nn.Sequential(res_block)
             self.output_features = in_dim  
-
-        self.print_architecture()
 
     def embedding_pooling(self, x, x_mask):
         return self.embedding(self.transformer(x, src_key_padding_mask=x_mask).sum(dim=1))
@@ -139,30 +81,3 @@ class TransformerEmbeddingCosineConfigurable(nn.Module):
 
     def get_weights(self):
         return [(name, param) for name, param in self.embedding.named_parameters()]
-
-    def print_architecture(self):
-        print("\nEmbedding Architecture:")
-        prev_dim = None
-
-        for name, module in self.embedding.named_modules():
-            if isinstance(module, ResBlock):
-                try:
-                    in_dim = module.block[1].in_features
-                    out_dim = module.block[-1].out_features
-                    res_type = "Identity" if isinstance(module.residual, nn.Identity) else "Linear"
-                    print(f"  {name}: ResBlock({in_dim} → {out_dim}), Residual: {res_type}")
-                    prev_dim = out_dim
-                except Exception as e:
-                    print(f"  {name}: ResBlock (error reading dims: {e})")
-            elif isinstance(module, nn.Linear) and name == "linear":
-                print(f"  {name}: Final Linear({prev_dim} → {module.out_features})")
-                prev_dim = module.out_features
-            elif isinstance(module, nn.Dropout):
-                print(f"  {name}: Dropout(p={module.p})")
-            elif isinstance(module, nn.ReLU):
-                print(f"  {name}: ReLU")
-            elif isinstance(module, nn.LayerNorm):
-                print(f"  {name}: LayerNorm({module.normalized_shape})")
-
-        print()
-

--- a/src/networks/transformer_nn.py
+++ b/src/networks/transformer_nn.py
@@ -76,3 +76,93 @@ class TransformerEmbeddingCosine(nn.Module):
 
     def get_weights(self):
         return [(name, param) for name, param in self.embedding.named_parameters()]
+
+
+class TransformerEmbeddingCosineConfigurable(nn.Module):
+    dropout = 0.1
+
+    def __init__(
+        self,
+        input_features=640,
+        dim_feedforward=1280,
+        hidden_layer=640,
+        nhead=10,
+        num_layers=6,
+        res_block_layers=0
+    ):
+        super().__init__()
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=input_features,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=self.dropout,
+            batch_first=True
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        if res_block_layers == 0:
+            self.embedding = nn.Sequential(OrderedDict([
+                ('norm', nn.LayerNorm(input_features)),
+                ('dropout', nn.Dropout(p=self.dropout)),
+                ('linear', nn.Linear(input_features, hidden_layer)),
+                ('activation', nn.ReLU())
+            ]))
+        else:
+            res_block = OrderedDict()
+            in_dim = input_features
+            block_id = 0  # needed for unique block names
+
+            for out_dim, count in res_block_layers:
+                for i in range(count):
+                    res_block[f'block{block_id}'] = ResBlock(in_dim, out_dim, self.dropout)
+                    in_dim = out_dim  # update input for next block
+                    block_id += 1
+
+            res_block.update([
+                ('dropout', nn.Dropout(p=self.dropout)),
+                ('linear', nn.Linear(in_dim, in_dim)),
+                ('activation', nn.ReLU())
+            ])
+
+            self.embedding = nn.Sequential(res_block)
+            self.output_features = in_dim  
+
+        self.print_architecture()
+
+    def embedding_pooling(self, x, x_mask):
+        return self.embedding(self.transformer(x, src_key_padding_mask=x_mask).sum(dim=1))
+
+    def forward(self, x, x_mask, y, y_mask):
+        return nn.functional.cosine_similarity(
+            self.embedding_pooling(x, x_mask),
+            self.embedding_pooling(y, y_mask)
+        )
+
+    def get_weights(self):
+        return [(name, param) for name, param in self.embedding.named_parameters()]
+
+    def print_architecture(self):
+        print("\nEmbedding Architecture:")
+        prev_dim = None
+
+        for name, module in self.embedding.named_modules():
+            if isinstance(module, ResBlock):
+                try:
+                    in_dim = module.block[1].in_features
+                    out_dim = module.block[-1].out_features
+                    res_type = "Identity" if isinstance(module.residual, nn.Identity) else "Linear"
+                    print(f"  {name}: ResBlock({in_dim} → {out_dim}), Residual: {res_type}")
+                    prev_dim = out_dim
+                except Exception as e:
+                    print(f"  {name}: ResBlock (error reading dims: {e})")
+            elif isinstance(module, nn.Linear) and name == "linear":
+                print(f"  {name}: Final Linear({prev_dim} → {module.out_features})")
+                prev_dim = module.out_features
+            elif isinstance(module, nn.Dropout):
+                print(f"  {name}: Dropout(p={module.p})")
+            elif isinstance(module, nn.ReLU):
+                print(f"  {name}: ReLU")
+            elif isinstance(module, nn.LayerNorm):
+                print(f"  {name}: LayerNorm({module.normalized_shape})")
+
+        print()
+

--- a/src/training/embedding_tm_score.py
+++ b/src/training/embedding_tm_score.py
@@ -19,6 +19,9 @@ from lightning_module.training.embedding_training import LitEmbeddingTraining
 from config.schema_config import TrainingConfig
 from lightning.pytorch.loggers import TensorBoardLogger
 
+# Use of high precision for matrix multiplication
+import torch
+torch.set_float32_matmul_precision('high')
 
 cs = ConfigStore.instance()
 cs.store(name="training_default", node=TrainingConfig)


### PR DESCRIPTION
This PR adds TransformerEmbeddingCosineConfigurable to be able to add the custom layers and hidden dimension

Usage:

embedding_network:
  _target_: networks.transformer_nn.TransformerEmbeddingCosineConfigurable
  input_features: 1536
  nhead: 12
  num_layers: 6
  dim_feedforward: 3072
  hidden_layer: 1536
  res_block_layers:
   # - [1536, 12]
     - [768, 12]
    #- [364, 12]